### PR TITLE
Fix a bug in the bootrom register

### DIFF
--- a/lib_gb/src/mmu/gb_mmu.rs
+++ b/lib_gb/src/mmu/gb_mmu.rs
@@ -155,7 +155,7 @@ impl<'a, D:AudioDevice> GbMmu<'a, D>{
         };
 
         //Setting the bootrom register to be set (the boot sequence has over)
-        mmu.io_components.write_unprotected(BOOT_REGISTER_ADDRESS - 0xFF00, 1);
+        mmu.write(BOOT_REGISTER_ADDRESS, 1);
         
         mmu
     }


### PR DESCRIPTION
Fix a bug where no bootrom supplied the bootrom
register would have been set but not the correspond variable.

In order to fix this the im using the write and not the
write_unprotected.