### PR TITLE
Remove the enable flag as it was a mistake

### DIFF
--- a/lib_gb/src/apu/apu_registers_updater.rs
+++ b/lib_gb/src/apu/apu_registers_updater.rs
@@ -44,9 +44,6 @@ pub fn set_nr44(channel:&mut Channel<NoiseSampleProducer>, fs:&FrameSequencer, n
 }
 
 pub fn set_nr50<AD:AudioDevice>(apu:&mut GbApu<AD>, nr50:u8){
-    apu.right_terminal.enabled = nr50 & BIT_3_MASK != 0;
-    apu.left_terminal.enabled = nr50 & BIT_7_MASK != 0;
-    
     apu.right_terminal.volume = nr50 & 0b111;
     apu.left_terminal.volume = (nr50 & 0b111_0000) >> 4;
 }

--- a/lib_gb/src/apu/sound_terminal.rs
+++ b/lib_gb/src/apu/sound_terminal.rs
@@ -6,7 +6,6 @@ const ENABLE_MASK:ChannelMask = 0xFFFF;
 const DISABLE_MASK:ChannelMask = 0x0;
 
 pub struct SoundTerminal{
-    pub enabled:bool,
     pub volume:u8,
     channel_masks:[ChannelMask;NUMBER_OF_CHANNELS]
 }
@@ -14,7 +13,6 @@ pub struct SoundTerminal{
 impl Default for SoundTerminal{
     fn default() -> Self {
         SoundTerminal{
-            enabled:false,
             channel_masks:[DISABLE_MASK;NUMBER_OF_CHANNELS],
             volume:0
         }


### PR DESCRIPTION
This was due to misunderstanding of the docs.
Those bits ware meant for the vin cartridge
 channel which no game ever used,
So there is no reason to emulate it.

Closes #56 