### PR TITLE
Fix an issue where legit oam writes are ignored

### DIFF
--- a/lib_gb/src/ppu/gb_ppu.rs
+++ b/lib_gb/src/ppu/gb_ppu.rs
@@ -70,7 +70,7 @@ impl<GFX:GfxDevice> GbPpu<GFX>{
             obj_color_mapping0: [None, Some(LIGHT_GRAY), Some(DARK_GRAY), Some(BLACK)],
             obj_color_mapping1: [None, Some(LIGHT_GRAY), Some(DARK_GRAY), Some(BLACK)],
             ly_register:0,
-            state: PpuState::OamSearch,
+            state: PpuState::Hblank,
             //interrupts
             v_blank_interrupt_request:false, 
             h_blank_interrupt_request:false,


### PR DESCRIPTION
When developing the bootrom for this emu I have noticed that the ppu
when constructed will stay on oam search mode instead hblank.
This caused for legit writes to the oam (before the
ppu is started for the first time) to be ignored