### PR TITLE
Allow to dynamic link to sdl2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
 dependencies = [
  "cc",
 ]

--- a/gb/Cargo.toml
+++ b/gb/Cargo.toml
@@ -14,7 +14,7 @@ lib_gb = {path = "../lib_gb/"}
 log = "0.4"
 fern = "0.6.0"
 chrono = "0.4"
-sdl2 = {package = "sdl2", version = "0.34"}
+sdl2 = "0.34"
 wav = "1.0"
 crossbeam-channel = "0.5"
 cfg-if = "1.0"

--- a/gb/Cargo.toml
+++ b/gb/Cargo.toml
@@ -14,11 +14,13 @@ lib_gb = {path = "../lib_gb/"}
 log = "0.4"
 fern = "0.6.0"
 chrono = "0.4"
-sdl2 = {version = "0.34", features = ["bundled","static-link"]}
+sdl2 = {package = "sdl2", version = "0.34"}
 wav = "1.0"
 crossbeam-channel = "0.5"
 cfg-if = "1.0"
 
 [features]
+default = ["static-sdl"]
 sdl-resample = []
 push-audio = []
+static-sdl = ["sdl2/bundled", "sdl2/static-link"]


### PR DESCRIPTION
Closes #66 

Doesn't automatically do this #66  but allow to link dynamicly without changing the repo.