### PR TITLE
Fix build of the rpi baremetal target

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -45,7 +45,6 @@ dependencies = ["build_rpi_baremetal","install_llvm_tools"]
 
 [tasks.build_rpi_baremetal]
 toolchain = "nightly"
-cwd = "./rpi/"
 command = "cargo"
 args = ["build", "--release", "--target", "armv7a-none-eabihf","--package", "magenboy_rpi", "--bin", "baremetal", "-Z", "build-std=core"]
 dependencies = ["install_rust_src"]

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,7 +1,11 @@
 use std::process::Command;
 
 fn main() {
+    let current_branch = std::fs::read_to_string("../.git/HEAD").unwrap();
+    let current_commit_file = std::path::Path::new("../.git").join(&current_branch[5..]);
+    let current_commit_file = current_commit_file.to_str().unwrap();
     println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed={}", current_commit_file);
 
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,10 +1,12 @@
 use std::process::Command;
 
 fn main() {
-    let current_branch = std::fs::read_to_string("../.git/HEAD").unwrap();
-    let current_commit_file = std::path::Path::new("../.git").join(&current_branch[5..]);
+    let git_path = std::path::Path::new("../.git");
+    let head_path = git_path.join("HEAD");
+    let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
+    let current_commit_file = git_path.join(&current_branch);
     let current_commit_file = current_commit_file.to_str().unwrap();
-    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
     println!("cargo:rerun-if-changed={}", current_commit_file);
 
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,6 +1,8 @@
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     let version = env!("CARGO_PKG_VERSION");

--- a/common/build.rs
+++ b/common/build.rs
@@ -5,9 +5,8 @@ fn main() {
     let head_path = git_path.join("HEAD");
     let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
     let current_commit_file = git_path.join(&current_branch);
-    let current_commit_file = current_commit_file.to_str().unwrap();
     println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
-    println!("cargo:rerun-if-changed={}", current_commit_file);
+    println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/rpi/.cargo/config.toml
+++ b/rpi/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.armv7a-none-eabihf]
-rustflags = [
-    "-Clink-arg=--script=./rpi/src/bin/baremetal/link.ld", 
-    "-Ctarget-feature=+virtualization"
-]

--- a/rpi/build.rs
+++ b/rpi/build.rs
@@ -2,7 +2,6 @@
 mod config{
     pub const RPI_ENV_VAR_NAME:&'static str = "RPI";
     pub const LD_SCRIPT_PATH:&str = "src/bin/baremetal/link.ld";
-    pub const CONFIG_FILE_PATH: &str = "config.txt";
     pub const CONFIG_TXT_CONTENT:&str = 
 "# configuration for the RPI
 arm_64bit=0 # boot to 32 bit mode
@@ -32,7 +31,14 @@ fn main(){
         println!("cargo:rustc-link-arg-bin=baremetal={}", ld_script_path);
 
         // Creates config.txt
-        std::fs::write(config::CONFIG_FILE_PATH, config::CONFIG_TXT_CONTENT).unwrap();
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        // Turns the out dir to the artifacts dir
+        let mut config_file_path = std::path::Path::new(&out_dir).to_path_buf();
+        config_file_path.pop();
+        config_file_path.pop();
+        config_file_path.pop();
+        config_file_path = config_file_path.join("config.txt");
+        std::fs::write(config_file_path, config::CONFIG_TXT_CONTENT).unwrap();
 
         // Add the cfg option `rpi` with that value of the env var `RPI`
         let rpi_version = std::env::var(config::RPI_ENV_VAR_NAME)

--- a/rpi/src/bin/baremetal/boot_armv7a.s
+++ b/rpi/src/bin/baremetal/boot_armv7a.s
@@ -1,3 +1,7 @@
+// Enabling all the features of the cortex-a72, currently rust has a bug preventing enabling with rustc 
+// For more see - https://github.com/rust-lang/rust/issues/127269
+.cpu cortex-a72
+
 // alias the PERIPHERALS_BASE_ADDRESS symbol at pointer
 // since it is a static global variable from the rust side
 .equ    PERIPHERALS_BASE_ADDRESS_PTR,   PERIPHERALS_BASE_ADDRESS


### PR DESCRIPTION
The problem was this bug in rust/llvm - https://github.com/rust-lang/rust/issues/127269

- Fix the git version not updating when the common is not rebuilt by
setting it to rebuild upon git head changing.
- Move the .cargo/config.toml logic to the build script to make it simpler 
- Move the config.txt output to the artifacts folder

Fixes #143 