### PR TITLE
Add CI for all targets and features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,5 +36,6 @@ jobs:
     - name: Build libretro
       run: cargo make libretro_desktop
     - name: rpi baremetal
-      run: rustup toolchain install nightly
-      run: cargo make -e RPI=4 rpibm
+      run: |
+       rustup toolchain install nightly
+       cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,13 +13,13 @@ jobs:
   build-and-test-all-targets:
     strategy: 
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        # toolchain: stable, nightly
+        toolchain: 1.73.0
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
@@ -28,11 +28,13 @@ jobs:
     - name: Run tests
       run: cargo make test
     # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
-    - name: rpi os  
+    - name: rpi os
+      if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
     - name: Build sdl
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
     - name: rpi baremetal
+      run: rustup toolchain install nightly
       run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,21 +11,26 @@ env:
 
 jobs:
   build-and-test-all-targets:
-    runs-on: ubuntu-latest
+    straregy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         rustflags: ""
         cache-directories: /home/runner/.cargo/bin
+        target: armv7a-none-eabihf
     - name: install cargo make
       run: cargo install cargo-make
     - name: Run tests
       run: cargo make test
+    # for some reason the sdl instalation making this fail (some error about not finding glibc) so this should before the sdl
+    - name: rpi os  
+      run: cargo make rpios
     - name: Build sdl
       run: cargo make sdl
-    - name: rpi os
-      run: cargo make rpios
     - name: Build libretro
       run: cargo make libretro_desktop
     - name: rpi baremetal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,15 +9,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-concurrency:
-  cancel-in-progress: false
-
 jobs:
   build-and-test-all-targets:
     strategy: 
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         rustflags: ""
         cache-directories: /home/runner/.cargo/bin
-        target: armv7a-none-eabihf
     - name: install cargo make
       run: cargo install cargo-make
     - name: Run tests
@@ -33,5 +32,12 @@ jobs:
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
+      
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: nightly
+        rustflags: ""
+        cache-directories: /home/runner/.cargo/bin
+        target: armv7a-none-eabihf
     - name: rpi baremetal
       run: cargo make rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.73.0, nightly-2023-10-05
-        target: aarch64-linux-android
+        # toolchain: 1.73.0, nightly-2023-10-05
+        # target: aarch64-linux-android
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  cancel-in-progress: false
+
 jobs:
   build-and-test-all-targets:
     strategy: 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Build sdl
       continue-on-error: true
       run: cargo make sdl
+    - name: Build sdl with debugger
+      continue-on-error: true
+      run: cargo make sdl_dbg
     - name: Build libretro
       continue-on-error: true
       run: cargo make libretro_desktop

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-test-all-targets:
-    straregy: 
+    strategy: 
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
     - name: install cargo make
-      run: cargo install cargo-make
+      run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
     - name: Run tests
       run: cargo make test
     # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,9 @@ jobs:
 
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
+      
+    - name: Build rpi baremetal
+      run: cargo make -e RPI=4 rpibm
 
     - name: Run tests
       run: cargo make test
@@ -44,6 +47,3 @@ jobs:
 
     - name: Build libretro
       run: cargo make libretro_desktop
-
-    - name: Build rpi baremetal
-      run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,12 @@ env:
 
 jobs:
   build-and-test-all-targets:
-    if: always()
     strategy: 
+      fail-fast: false  # Allow the other job to continue running
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -23,26 +24,26 @@ jobs:
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
-    - name: fail test
-      run: exit 1
+
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
+
     - name: Run tests
       run: cargo make test
+
     # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
     - name: Build rpi os
-      continue-on-error: true
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
+
     - name: Build sdl
-      continue-on-error: true
       run: cargo make sdl
+
     - name: Build sdl with debugger
-      continue-on-error: true
       run: cargo make sdl_dbg
+
     - name: Build libretro
-      continue-on-error: true
       run: cargo make libretro_desktop
+
     - name: Build rpi baremetal
-      continue-on-error: true
       run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,13 +20,13 @@ jobs:
         cache-directories: /home/runner/.cargo/bin
     - name: install cargo make
       run: cargo install cargo-make
-    - name: rpi os
-      run: cargo make rpios
     - name: Run tests
       run: cargo make test
     - name: Build sdl
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
+    - name: rpi os
+      run: cargo make rpios
     - name: rpi baremetal
       run: cargo make rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  install_deps:
+  build-and-test-all-targets:
+  
+    continue-on-error: true
+    if: always()
     strategy: 
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -24,73 +27,22 @@ jobs:
           C:\\Users\\runneradmin\\.cargo\\bin"
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
-
-  test:
-    strategy: 
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    needs: install_deps
-    steps:  
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        rustflags: ""
-        cache-directories: "/home/runner/.cargo/bin
-          C:\\Users\\runneradmin\\.cargo\\bin"
     - name: Run tests
       run: cargo make test
-
-  build-rpi:
-    strategy: 
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    needs: install_deps
-    steps:  
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        rustflags: ""
-        cache-directories: "/home/runner/.cargo/bin
-          C:\\Users\\runneradmin\\.cargo\\bin"
-    - name: Build
-      # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
+    # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
+    - name: Build rpi os
+      continue-on-error: true
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
-    - name: Build rpi baremetal
-      run: cargo make -e RPI=4 rpibm
-
-  build-sdl:
-    strategy: 
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    needs: install_deps
-    steps:  
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        rustflags: ""
-        cache-directories: "/home/runner/.cargo/bin
-          C:\\Users\\runneradmin\\.cargo\\bin"
-    - name: Build
+    - name: Build sdl
+      continue-on-error: true
       run: cargo make sdl
-    - name: Build with debugger
+    - name: Build sdl with debugger
+      continue-on-error: true
       run: cargo make sdl_dbg
-
-  build-libretro:
-    strategy: 
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    needs: install_deps
-    steps:  
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        rustflags: ""
-        cache-directories: "/home/runner/.cargo/bin
-          C:\\Users\\runneradmin\\.cargo\\bin"
     - name: Build libretro
+      continue-on-error: true
       run: cargo make libretro_desktop
+    - name: Build rpi baremetal
+      continue-on-error: true
+      run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -28,14 +27,16 @@ jobs:
     - name: Run tests
       run: cargo make test
     # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
-    - name: rpi os
+    - name: Build rpi os
+      continue-on-error: true
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
     - name: Build sdl
+      continue-on-error: true
       run: cargo make sdl
     - name: Build libretro
+      continue-on-error: true
       run: cargo make libretro_desktop
-    - name: rpi baremetal
-      run: |
-       rustup toolchain install nightly
-       cargo make -e RPI=4 rpibm
+    - name: Build rpi baremetal
+      continue-on-error: true
+      run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,6 @@ env:
 
 jobs:
   build-and-test-all-targets:
-  
-    continue-on-error: true
     if: always()
     strategy: 
       matrix:
@@ -25,6 +23,8 @@ jobs:
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
+    - name: fail test
+      run: exit 1
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test-all-targets:
     strategy: 
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:  
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,9 @@ jobs:
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
 
+    - name: Build rpi baremetal
+      run: cargo make -e RPI=4 rpibm
+
     - name: Run tests
       run: cargo make test
 
@@ -36,9 +39,6 @@ jobs:
     - name: Build rpi os
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
-
-    - name: Build rpi baremetal
-      run: cargo make -e RPI=4 rpibm
 
     - name: Build sdl
       run: cargo make sdl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.73.0
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: 1.73.0 # Minimum supported version by the project
         rustflags: ""
+        cache-directories: /home/runner/.cargo/bin
     - name: install cargo make
       run: cargo install cargo-make
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-and-test-all-targets:
-    strategy: 
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+  strategy: 
+    matrix:
+      os: [ubuntu-latest, windows-latest]
+  install_deps:
     runs-on: ${{ matrix.os }}
     steps:  
     - uses: actions/checkout@v4
@@ -24,22 +24,61 @@ jobs:
           C:\\Users\\runneradmin\\.cargo\\bin"
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: install_deps
+    steps:  
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-directories: "/home/runner/.cargo/bin
+          C:\\Users\\runneradmin\\.cargo\\bin"
     - name: Run tests
       run: cargo make test
-    # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
-    - name: Build rpi os
-      continue-on-error: true
+
+  build-rpi:
+    runs-on: ${{ matrix.os }}
+    needs: install_deps
+    steps:  
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-directories: "/home/runner/.cargo/bin
+          C:\\Users\\runneradmin\\.cargo\\bin"
+    - name: Build
+      # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
-    - name: Build sdl
-      continue-on-error: true
-      run: cargo make sdl
-    - name: Build sdl with debugger
-      continue-on-error: true
-      run: cargo make sdl_dbg
-    - name: Build libretro
-      continue-on-error: true
-      run: cargo make libretro_desktop
     - name: Build rpi baremetal
-      continue-on-error: true
       run: cargo make -e RPI=4 rpibm
+
+  build-sdl:
+    runs-on: ${{ matrix.os }}
+    needs: install_deps
+    steps:  
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-directories: "/home/runner/.cargo/bin
+          C:\\Users\\runneradmin\\.cargo\\bin"
+    - name: Build
+      run: cargo make sdl
+    - name: Build with debugger
+      run: cargo make sdl_dbg
+
+  build-libretro:
+    runs-on: ${{ matrix.os }}
+    needs: install_deps
+    steps:  
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-directories: "/home/runner/.cargo/bin
+          C:\\Users\\runneradmin\\.cargo\\bin"
+    - name: Build libretro
+      run: cargo make libretro_desktop

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,11 @@ jobs:
 
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
-
-    - name: Build rpi baremetal
-      run: cargo make -e RPI=4 rpibm
+      
+    - name: Build libretro android
+      run: cargo make libretro_android
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
     - name: Run tests
       run: cargo make test
@@ -45,6 +47,9 @@ jobs:
     - name: Build rpi os
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
+      
+    - name: Build rpi baremetal
+      run: cargo make -e RPI=4 rpibm
 
     - name: Build sdl
       run: cargo make sdl
@@ -54,8 +59,3 @@ jobs:
 
     - name: Build libretro desktop
       run: cargo make libretro_desktop
-
-    - name: Build libretro android
-      run: cargo make libretro_android
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: stable, nightly
+        # toolchain: stable, nightly
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
@@ -27,7 +27,7 @@ jobs:
       run: cargo install cargo-make
     - name: Run tests
       run: cargo make test
-    # for some reason the sdl instalation making this fail (some error about not finding glibc) so this should before the sdl
+    # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
     - name: rpi os  
       run: cargo make rpios
     - name: Build sdl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,11 +22,11 @@ jobs:
       run: cargo install cargo-make
     - name: Run tests
       run: cargo make test
+    - name: rpi os
+      run: cargo make rpios
     - name: Build sdl
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
-    - name: rpi os
-      run: cargo make rpios
     - name: rpi baremetal
       run: cargo make rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,26 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  install-deps:
+  build-and-test-all-targets:
     runs-on: ubuntu-latest
     steps:  
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: install cargo make
       run: cargo install cargo-make
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run tests
       run: cargo make test
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Build sdl
       run: cargo make sdl
     - name: Build libretro

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/all_targets_ci ]
   pull_request:
     branches: [ master, feature/*, fix/* ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,8 @@ jobs:
       with:
         toolchain: stable, nightly
         rustflags: ""
-        cache-directories: /home/runner/.cargo/bin
+        cache-directories: "/home/runner/.cargo/bin
+          C:\\Users\\runneradmin\\.cargo\\bin"
     - name: install cargo make
       run: cargo install cargo-make
     - name: Run tests
@@ -34,4 +35,4 @@ jobs:
     - name: Build libretro
       run: cargo make libretro_desktop
     - name: rpi baremetal
-      run: cargo make rpibm
+      run: cargo make -e RPI=4 rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.73.0, nightly-2023-10-05
+        target: aarch64-linux-android
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,15 +31,15 @@ jobs:
       id: setup-ndk
       with:
         ndk-version: r25  # This is the minimum version rust supports
-        add-to-path: false
+        add-to-path: true
 
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
       
     - name: Build libretro android
       run: cargo make libretro_android
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      # env:
+      #   ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
     - name: Run tests
       run: cargo make test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-and-test:
-
+  install-deps:
     runs-on: ubuntu-latest
+    steps:  
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: install cargo make
+      run: cargo install cargo-make
 
+  test:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build sdl
-      run: cargo build --verbose --package magenboy_sdl
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run tests
-      run: cargo test --verbose --package magenboy_core
+      run: cargo make test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Build sdl
+      run: cargo make sdl
+    - name: Build libretro
+      run: cargo make libretro_desktop
+    - name: rpi os
+      run: cargo make rpios
+    - name: rpi baremetal
+      run: cargo make rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,12 @@ jobs:
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
 
+    - uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r25  # This is the minimum version rust supports
+        add-to-path: false
+
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
 
@@ -46,5 +52,10 @@ jobs:
     - name: Build sdl with debugger
       run: cargo make sdl_dbg
 
-    - name: Build libretro
+    - name: Build libretro desktop
       run: cargo make libretro_desktop
+
+    - name: Build libretro android
+      run: cargo make libretro_android
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ jobs:
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: 1.73.0 # Minimum supported version by the project
+        rustflags: ""
     - name: install cargo make
       run: cargo install cargo-make
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,10 @@ jobs:
       run: cargo install cargo-make
     - name: Run tests
       run: cargo make test
-    - name: rpi os
-      run: cargo make rpios
     - name: Build sdl
       run: cargo make sdl
+    - name: rpi os
+      run: cargo make rpios
     - name: Build libretro
       run: cargo make libretro_desktop
     - name: rpi baremetal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: stable, fnightly
+        toolchain: stable, nightly
         rustflags: ""
         cache-directories: /home/runner/.cargo/bin
     - name: install cargo make

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,8 @@ jobs:
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # Stable toolchains are installed with rust-toolchain.toml and the rest toolchains and targets are installed by Makefile.toml
       with:
-        # toolchain: 1.73.0, nightly-2023-10-05
-        # target: aarch64-linux-android
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
@@ -35,16 +34,11 @@ jobs:
 
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
-      
-    - name: Build libretro android
-      run: cargo make libretro_android
-      # env:
-      #   ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
     - name: Run tests
       run: cargo make test
 
-    # for some reason the sdl installation causing this to fail (some error about not finding glibc) so this should before the sdl
+    # For some reason the other installation causing this to fail (some error about not finding glibc) so this should come first
     - name: Build rpi os
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
@@ -60,3 +54,6 @@ jobs:
 
     - name: Build libretro desktop
       run: cargo make libretro_desktop
+
+    - name: Build libretro android
+      run: cargo make libretro_android

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,15 +21,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        toolchain: 1.73.0, nightly-2023-10-05
         rustflags: ""
         cache-directories: "/home/runner/.cargo/bin
           C:\\Users\\runneradmin\\.cargo\\bin"
 
     - name: install cargo make
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
-      
-    - name: Build rpi baremetal
-      run: cargo make -e RPI=4 rpibm
 
     - name: Run tests
       run: cargo make test
@@ -38,6 +36,9 @@ jobs:
     - name: Build rpi os
       if: ${{ matrix.os == 'ubuntu-latest' }}  # This fails on windows since it does not have docker installed
       run: cargo make rpios
+
+    - name: Build rpi baremetal
+      run: cargo make -e RPI=4 rpibm
 
     - name: Build sdl
       run: cargo make sdl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  strategy: 
-    matrix:
-      os: [ubuntu-latest, windows-latest]
   install_deps:
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:  
     - uses: actions/checkout@v4
@@ -26,6 +26,9 @@ jobs:
       run: cargo install --no-default-features --locked --version 0.37.23 cargo-make
 
   test:
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: install_deps
     steps:  
@@ -39,6 +42,9 @@ jobs:
       run: cargo make test
 
   build-rpi:
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: install_deps
     steps:  
@@ -56,6 +62,9 @@ jobs:
       run: cargo make -e RPI=4 rpibm
 
   build-sdl:
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: install_deps
     steps:  
@@ -71,6 +80,9 @@ jobs:
       run: cargo make sdl_dbg
 
   build-libretro:
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: install_deps
     steps:  

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,13 +20,13 @@ jobs:
         cache-directories: /home/runner/.cargo/bin
     - name: install cargo make
       run: cargo install cargo-make
+    - name: rpi os
+      run: cargo make rpios
     - name: Run tests
       run: cargo make test
     - name: Build sdl
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
-    - name: rpi os
-      run: cargo make rpios
     - name: rpi baremetal
       run: cargo make rpibm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master, feature/all_targets_ci ]
+    branches: [ master ]
   pull_request:
     branches: [ master, feature/*, fix/* ]
 
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    
+
     steps:  
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        toolchain: stable, fnightly
         rustflags: ""
         cache-directories: /home/runner/.cargo/bin
     - name: install cargo make
@@ -32,12 +33,5 @@ jobs:
       run: cargo make sdl
     - name: Build libretro
       run: cargo make libretro_desktop
-      
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly
-        rustflags: ""
-        cache-directories: /home/runner/.cargo/bin
-        target: armv7a-none-eabihf
     - name: rpi baremetal
       run: cargo make rpibm

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -50,7 +50,7 @@ args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bi
 
 [tasks.pre-rpibm]
 command = "rustup"
-args = ["toolchain", "install", "--profile", "minimal", "--force", "${nightly_version}"]
+args = ["toolchain", "install", "--profile", "minimal", "--no-self-update", "${nightly_version}"]
 
 [tasks.rpibm]
 toolchain = "${nightly_version}"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,7 @@ try_install libsdl2-dev
 ]
 
 [tasks.rpios]
-install_crate = {crate_name = "cross", binary = "cross", test_arg = "-h"}
+install_crate = {crate_name = "cross", binary = "cross", test_arg = "-h", install_crate_args="--locked"}
 command = "cross"
 args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bin", "rpios","--no-default-features", "--features", "os"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,8 @@ try_install libsdl2-dev
 ]
 
 [tasks.rpios]
-install_crate = {crate_name = "cross", binary = "cross", test_arg = "-h", install_crate_args="--locked"}
+install_crate = {crate_name = "cross", binary = "cross", test_arg = "-h"}
+install_crate_args=["--locked", "--version", "0.2.5"]
 command = "cross"
 args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bin", "rpios","--no-default-features", "--features", "os"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -50,7 +50,7 @@ args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bi
 
 [tasks.pre-rpibm]
 command = "rustup"
-args = ["toolchain", "install", "--profile", "minimal", "${nightly_version}"]
+args = ["toolchain", "install", "--profile", "minimal", "--force", "${nightly_version}"]
 
 [tasks.rpibm]
 toolchain = "${nightly_version}"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -81,5 +81,6 @@ args = ["build", "--release", "--package", "magenboy_libretro"]
 
 [tasks.libretro_android]
 install_crate = {crate_name = "cargo-ndk", binary = "cargo", test_arg = "ndk"}
+install_crate_args=["--locked", "--version", "3.5.4"]
 command = "cargo"
 args = ["ndk", "--target=aarch64-linux-android", "build", "--release", "--package", "magenboy_libretro"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -24,7 +24,7 @@ args = ["build", "--release", "--package", "magenboy_sdl", "--no-default-feature
 dependencies = ["install_sdl2_linux"]
 
 [tasks.sdl_dbg.linux]
-args = ["build", "--release", "--package", "magenboy_sdl", "--no-default-features", "-features", "dbg"]
+args = ["build", "--release", "--package", "magenboy_sdl", "--no-default-features", "--features", "dbg"]
 dependencies = ["install_sdl2_linux"]
 
 [tasks.install_sdl2_linux]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -84,3 +84,8 @@ install_crate = {crate_name = "cargo-ndk", binary = "cargo", test_arg = "ndk"}
 install_crate_args=["--locked", "--version", "3.5.4"]
 command = "cargo"
 args = ["ndk", "--target=aarch64-linux-android", "build", "--release", "--package", "magenboy_libretro"]
+dependencies = ["add_android_target"]
+
+[tasks.add_android_target]
+command = "rustup"
+args = ["target", "install", "aarch64-linux-android"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,9 @@
 [config]
 default_to_workspace = false
 
+[env]
+nightly_version = "nightly-2023-10-05"
+
 [tasks.all]
 dependencies = ["test", "sdl", "rpios", "rpibm", "libretro"]
 
@@ -37,25 +40,29 @@ install_crate_args=["--locked", "--version", "0.2.5"]
 command = "cross"
 args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bin", "rpios","--no-default-features", "--features", "os"]
 
+[tasks.pre-rpibm]
+command = "rustup"
+args = ["toolchain", "install", "${nightly_version}"]
+
 [tasks.rpibm]
-toolchain = "nightly"
+toolchain = "${nightly_version}"
 install_crate = "cargo-binutils"
 command = "rust-objcopy"
 args = ["target/armv7a-none-eabihf/release/baremetal", "-O", "binary", "kernel7.img"]
-dependencies = ["build_rpi_baremetal","install_llvm_tools"]
+dependencies = ["pre-rpibm", "build_rpi_baremetal","install_llvm_tools"]
 
 [tasks.build_rpi_baremetal]
-toolchain = "nightly"
+toolchain = "${nightly_version}"
 command = "cargo"
 args = ["build", "--release", "--target", "armv7a-none-eabihf","--package", "magenboy_rpi", "--bin", "baremetal", "-Z", "build-std=core"]
 dependencies = ["install_rust_src"]
 
 [tasks.install_llvm_tools]
-toolchain = "nightly"
+toolchain = "${nightly_version}"
 install_crate = {rustup_component_name = "llvm-tools-preview"}
 
 [tasks.install_rust_src]
-toolchain = "nightly"
+toolchain = "${nightly_version}"
 command = "rustup"
 args = ["component", "add", "rust-src"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,8 +15,16 @@ args = ["test", "--package", "magenboy_core"]
 command = "cargo"
 args = ["build", "--release", "--package", "magenboy_sdl"]
 
+[tasks.sdl_dbg]
+command = "cargo"
+args = ["build", "--release", "--package", "magenboy_sdl", "--features", "dbg"]
+
 [tasks.sdl.linux]
 args = ["build", "--release", "--package", "magenboy_sdl", "--no-default-features"]
+dependencies = ["install_sdl2_linux"]
+
+[tasks.sdl_dbg.linux]
+args = ["build", "--release", "--package", "magenboy_sdl", "--no-default-features", "-features", "dbg"]
 dependencies = ["install_sdl2_linux"]
 
 [tasks.install_sdl2_linux]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,7 +2,7 @@
 default_to_workspace = false
 
 [env]
-nightly_version = "nightly-2023-10-05"
+nightly_version = "nightly-2023-10-05"  # 1.73.0 toolchain nightly version
 
 [tasks.all]
 dependencies = ["test", "sdl", "rpios", "rpibm", "libretro"]
@@ -50,10 +50,10 @@ args = ["build", "--release", "--target", "armv7-unknown-linux-gnueabihf", "--bi
 
 [tasks.pre-rpibm]
 command = "rustup"
-args = ["toolchain", "install", "${nightly_version}"]
+args = ["toolchain", "install", "--profile", "minimal", "${nightly_version}"]
 
 [tasks.rpibm]
-toolchain = "${nightly_version}"
+# toolchain = "${nightly_version}"
 install_crate = "cargo-binutils"
 command = "rust-objcopy"
 args = ["target/armv7a-none-eabihf/release/baremetal", "-O", "binary", "kernel7.img"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -53,6 +53,7 @@ command = "rustup"
 args = ["toolchain", "install", "--profile", "minimal", "${nightly_version}"]
 
 [tasks.rpibm]
+toolchain = "${nightly_version}"
 install_crate = "cargo-binutils"
 install_crate_args=["--locked", "--version", "0.3.6"]
 command = "rust-objcopy"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -53,8 +53,8 @@ command = "rustup"
 args = ["toolchain", "install", "--profile", "minimal", "${nightly_version}"]
 
 [tasks.rpibm]
-# toolchain = "${nightly_version}"
 install_crate = "cargo-binutils"
+install_crate_args=["--locked", "--version", "0.3.6"]
 command = "rust-objcopy"
 args = ["target/armv7a-none-eabihf/release/baremetal", "-O", "binary", "kernel7.img"]
 dependencies = ["pre-rpibm", "build_rpi_baremetal","install_llvm_tools"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,9 +4,6 @@ default_to_workspace = false
 [env]
 nightly_version = "nightly-2023-10-05"  # 1.73.0 toolchain nightly version
 
-[tasks.all]
-dependencies = ["test", "sdl", "rpios", "rpibm", "libretro"]
-
 [tasks.test]
 command = "cargo"
 args = ["test", "--package", "magenboy_core"]
@@ -88,4 +85,4 @@ dependencies = ["add_android_target"]
 
 [tasks.add_android_target]
 command = "rustup"
-args = ["target", "install", "aarch64-linux-android"]
+args = ["target", "add", "aarch64-linux-android"]

--- a/common/build.rs
+++ b/common/build.rs
@@ -3,10 +3,10 @@ use std::process::Command;
 fn main() {
     let git_path = std::path::Path::new("../.git");
     let head_path = git_path.join("HEAD");
-    // let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
-    // let current_commit_file = git_path.join(&current_branch);
+    let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
+    let current_commit_file = git_path.join(&current_branch);
     println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
-    // println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,12 +1,12 @@
 use std::process::Command;
 
 fn main() {
-    let git_path = std::path::Path::new("../.git");
-    let head_path = git_path.join("HEAD");
-    let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
-    let current_commit_file = git_path.join(&current_branch);
-    println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
-    println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
+    // let git_path = std::path::Path::new("../.git");
+    // let head_path = git_path.join("HEAD");
+    // let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
+    // let current_commit_file = git_path.join(&current_branch);
+    // println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
+    // println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
     // let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
     // let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/common/build.rs
+++ b/common/build.rs
@@ -8,9 +8,8 @@ fn main() {
     // println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
     // println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
-    // let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
-    // let git_hash = String::from_utf8(output.stdout).unwrap();
-    let git_hash = "0";
+    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
     let version = env!("CARGO_PKG_VERSION");
     println!("cargo:rustc-env=MAGENBOY_VERSION={}", std::format!("{}-{}", version, git_hash));
 }

--- a/common/build.rs
+++ b/common/build.rs
@@ -8,8 +8,9 @@ fn main() {
     println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
     println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
-    let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
+    // let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();
+    // let git_hash = String::from_utf8(output.stdout).unwrap();
+    let git_hash = "0";
     let version = env!("CARGO_PKG_VERSION");
     println!("cargo:rustc-env=MAGENBOY_VERSION={}", std::format!("{}-{}", version, git_hash));
 }

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,11 +1,11 @@
 use std::process::Command;
 
 fn main() {
-    // let git_path = std::path::Path::new("../.git");
-    // let head_path = git_path.join("HEAD");
+    let git_path = std::path::Path::new("../.git");
+    let head_path = git_path.join("HEAD");
     // let current_branch = std::fs::read_to_string(&head_path).unwrap().replace("refs: ", "");
     // let current_commit_file = git_path.join(&current_branch);
-    // println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", head_path.to_str().unwrap());
     // println!("cargo:rerun-if-changed={}", current_commit_file.to_str().unwrap());
 
     let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output().unwrap();

--- a/rpi/build.rs
+++ b/rpi/build.rs
@@ -44,9 +44,9 @@ fn main(){
         let rpi_version = std::env::var(config::RPI_ENV_VAR_NAME)
             .expect(std::format!("{} env must be set", config::RPI_ENV_VAR_NAME).as_str());
         println!("cargo:rustc-cfg=rpi=\"{}\"", rpi_version);
-
-        // Silent warnings for this cfg 
-        println!("cargo::rustc-check-cfg=cfg(rpi, values(\"4\", \"2\"))");
-        println!("cargo::rustc-check-cfg=cfg(rpi)");
     }
+    
+    // Silent warnings for this cfg 
+    println!("cargo::rustc-check-cfg=cfg(rpi, values(\"4\", \"2\"))");
+    println!("cargo::rustc-check-cfg=cfg(rpi)");
 }

--- a/rpi/build.rs
+++ b/rpi/build.rs
@@ -44,9 +44,11 @@ fn main(){
         let rpi_version = std::env::var(config::RPI_ENV_VAR_NAME)
             .expect(std::format!("{} env must be set", config::RPI_ENV_VAR_NAME).as_str());
         println!("cargo:rustc-cfg=rpi=\"{}\"", rpi_version);
+    
+        // Silent warnings for this cfg     
+        println!("cargo:rustc-check-cfg=cfg(rpi, values(\"4\", \"2\"))");
     }
     
     // Silent warnings for this cfg 
-    println!("cargo::rustc-check-cfg=cfg(rpi, values(\"4\", \"2\"))");
-    println!("cargo::rustc-check-cfg=cfg(rpi)");
+    println!("cargo:rustc-check-cfg=cfg(rpi)");
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.73.0"
+components = [ "rust-src" ]
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,3 @@
 channel = "1.73.0"
 components = [ "rust-src" ]
 profile = "minimal"
-targets = ["aarch64-linux-android", "armv7a-none-eabihf"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
 channel = "1.73.0"
 components = [ "rust-src" ]
-profile = "default"
+profile = "minimal"
+targets = ["aarch64-linux-android", "armv7a-none-eabihf"]


### PR DESCRIPTION
- Make sure the repo will run against compatible rust version (1.73) 
  - Add rust-toolchain.toml file
  - lock make and the CI to compatible nightly versions 

Closes #116 