### PR TITLE
Fix Pokemon Pinball and improve debugger

### DIFF
--- a/common/src/initialization.rs
+++ b/common/src/initialization.rs
@@ -73,6 +73,7 @@ pub fn init_and_run_gameboy(
     EMULATOR_STATE.running.store(true, std::sync::atomic::Ordering::Relaxed);
     while EMULATOR_STATE.running.load(std::sync::atomic::Ordering::Relaxed){
         if !EMULATOR_STATE.pause.load(std::sync::atomic::Ordering::SeqCst){
+            // Locking the state mutex in order to signal the menu that we are cycling a frame now
             let state = &EMULATOR_STATE;
             let _mutex_ctx = state.state_mutex.lock().unwrap();
             gameboy.cycle_frame();

--- a/core/src/debugger/mod.rs
+++ b/core/src/debugger/mod.rs
@@ -79,7 +79,7 @@ pub enum DebuggerResult{
     MemoryDump(u16, u16, Vec<u8>),
     Disassembly(u16, u16, Vec<OpcodeEntry>),
     AddedWatch(Address),
-    HitWatch(u16, u16, u16, u16, u8),
+    HitWatch(Address, Address, u8),
     RemovedWatch(Address),
     WatchDoNotExist(Address),
     PpuInfo(PpuInfo),
@@ -164,8 +164,8 @@ impl_gameboy!{{
             if self.debugger.check_for_break(self.cpu.program_counter, self.mmu.get_current_bank(self.cpu.program_counter)){
                 self.debugger.send(DebuggerResult::HitBreak(self.cpu.program_counter, self.mmu.get_current_bank(self.cpu.program_counter)));
             }
-            if let Some((addr, bank, val)) = self.mmu.mem_watch.hit_addr{
-                self.debugger.send(DebuggerResult::HitWatch(addr, bank, self.cpu.program_counter, self.mmu.get_current_bank(self.cpu.program_counter), val));
+            if let Some((hit_address, val)) = self.mmu.mem_watch.hit_addr{
+                self.debugger.send(DebuggerResult::HitWatch(hit_address, Address { mem_addr: self.cpu.program_counter, bank: self.mmu.get_current_bank(self.cpu.program_counter) }, val));
                 self.mmu.mem_watch.hit_addr = None;
             }
             match self.debugger.recv(){
@@ -225,7 +225,7 @@ impl_gameboy!{{
 
 pub struct MemoryWatcher{
     pub watching_addresses: HashMap<Address, (WatchMode, Option<u8>)>,
-    pub hit_addr:Option<(u16, u16, u8)>,
+    pub hit_addr:Option<(Address, u8)>,
     pub current_rom_bank_number: u16,
     pub current_ram_bank_number: u8,
 }

--- a/core/src/machine/mbc_initializer.rs
+++ b/core/src/machine/mbc_initializer.rs
@@ -28,7 +28,8 @@ pub fn initialize_mbc(program:&[u8], save_data:Option<&[u8]>)->&'static mut dyn 
         0x12 => static_alloc(Mbc3::new(program_clone,false,None)),
         0x19 | 
         0x1A => static_alloc(Mbc5::new(program_clone, false, save_data_clone)),
-        0x1B => static_alloc(Mbc5::new(program_clone, true, save_data_clone)),
+        0x1B |
+        0x1E => static_alloc(Mbc5::new(program_clone, true, save_data_clone)),
         _=> core::panic!("not supported cartridge: {:#X}",mbc_type)
     };
     

--- a/core/src/mmu/carts/mbc1.rs
+++ b/core/src/mmu/carts/mbc1.rs
@@ -43,14 +43,19 @@ impl<'a> Mbc for Mbc1<'a>{
         if self.ram.is_empty(){
             return 0xFF;
         }
+        
         let bank:u16 = self.get_current_ram_bank() as u16;
-        return self.ram[(bank as usize * RAM_BANK_SIZE) + address as usize];
+        let address = (bank as usize * RAM_BANK_SIZE) + address as usize;
+        let address = get_external_ram_valid_address(address, &self.ram);
+        return self.ram[address];
     }
 
     fn write_external_ram(&mut self, address: u16, value: u8){
         if self.ram.len() > 0{
             let bank:u16 = self.get_current_ram_bank() as u16;
-            self.ram[(bank as usize * RAM_BANK_SIZE) + address as usize] = value;
+            let address = (bank as usize * RAM_BANK_SIZE) + address as usize;
+            let address = get_external_ram_valid_address(address, &self.ram);
+            self.ram[address] = value;
         }
     }
     

--- a/core/src/mmu/carts/mbc3.rs
+++ b/core/src/mmu/carts/mbc3.rs
@@ -56,7 +56,8 @@ impl<'a> Mbc for Mbc3<'a>{
         return match self.ram_rtc_select{
             0..=3=>{
                 let internal_address = self.ram_rtc_select as usize * RAM_BANK_SIZE as usize +  address as usize;
-                return self.ram[internal_address];
+                let address = get_external_ram_valid_address(internal_address, &self.ram);
+                return self.ram[address];
             },
             0x8..=0xC=>self.rtc_registers[(self.ram_rtc_select - 8) as usize],
             _=>EXTERNAL_RAM_READ_ERROR_VALUE
@@ -68,7 +69,8 @@ impl<'a> Mbc for Mbc3<'a>{
             match self.ram_rtc_select{
                 0..=3=>{
                     let internal_address = self.ram_rtc_select as usize * RAM_BANK_SIZE as usize +  address as usize;
-                    self.ram[internal_address] = value;
+                    let address = get_external_ram_valid_address(internal_address, &self.ram);
+                    self.ram[address] = value;
                 },
                 0x8..=0xC=>self.rtc_registers[(self.ram_rtc_select - 8) as usize] = value,
                 _=>{}

--- a/core/src/mmu/carts/mbc5.rs
+++ b/core/src/mmu/carts/mbc5.rs
@@ -46,7 +46,7 @@ impl<'a> Mbc for Mbc5<'a> {
     fn read_external_ram(&self, address:u16)->u8 {
         if self.ram_enable_register == ENABLE_RAM_VALUE{
             let bank = (self.ram_bank_number & 0xF) as usize * RAM_BANK_SIZE;
-            return self.ram[address as usize + bank];
+            return *self.ram.get(address as usize + bank).unwrap_or(&0xFF);
         }
 
         // ram is disabled
@@ -56,7 +56,9 @@ impl<'a> Mbc for Mbc5<'a> {
     fn write_external_ram(&mut self, address:u16, value:u8) {
         if self.ram_enable_register == ENABLE_RAM_VALUE{
             let bank = (self.ram_bank_number & 0xF) as usize * RAM_BANK_SIZE;
-            self.ram[address as usize + bank] = value;
+            if let Some(memory_cell) = self.ram.get_mut(address as usize + bank){
+                *memory_cell = value;
+            }
         }
         else{
             log::warn!("MBC5 write while ram is not enabled. ram_address: {}, value: {}", address, value);

--- a/core/src/mmu/carts/mbc5.rs
+++ b/core/src/mmu/carts/mbc5.rs
@@ -46,7 +46,7 @@ impl<'a> Mbc for Mbc5<'a> {
     fn read_external_ram(&self, address:u16)->u8 {
         if self.ram_enable_register == ENABLE_RAM_VALUE{
             let bank = self.ram_bank_number as usize * RAM_BANK_SIZE;
-            let address= (address as usize + bank) & self.ram.len() - 1;    // Clip the address to the boudries of the ram assuming that ram len is multiple of 2
+            let address= get_external_ram_valid_address(address as usize + bank, &self.ram);
             return self.ram[address];
         }
 
@@ -57,7 +57,7 @@ impl<'a> Mbc for Mbc5<'a> {
     fn write_external_ram(&mut self, address:u16, value:u8) {
         if self.ram_enable_register == ENABLE_RAM_VALUE{
             let bank = self.ram_bank_number as usize * RAM_BANK_SIZE;
-            let address= (address as usize + bank) & self.ram.len() - 1;    // Clip the address to the boudries of the ram assuming that ram len is multiple of 2
+            let address= get_external_ram_valid_address(address as usize + bank, &self.ram);
             self.ram[address] = value;
         }
     }

--- a/core/src/mmu/carts/mod.rs
+++ b/core/src/mmu/carts/mod.rs
@@ -20,7 +20,7 @@ pub fn get_ram_size(ram_size_register:u8)->usize{
     match ram_size_register{
         0x0=>0,
         0x1=>0x800,     // Unofficial - Undefined according to official docs
-        0x2=>0x4000,
+        0x2=>0x2000,
         0x3=>0x8000,
         0x4=>0x2_0000,
         0x5=>0x1_0000,

--- a/core/src/mmu/carts/mod.rs
+++ b/core/src/mmu/carts/mod.rs
@@ -16,7 +16,7 @@ pub const RAM_BANK_SIZE:usize = 0x2000;
 pub const CGB_FLAG_ADDRESS:usize = 0x143;
 pub const MBC_RAM_SIZE_LOCATION:usize = 0x149;
 
-pub fn get_ram_size(ram_size_register:u8)->usize{
+fn get_ram_size(ram_size_register:u8)->usize{
     match ram_size_register{
         0x0=>0,
         0x1=>0x800,     // Unofficial - Undefined according to official docs
@@ -41,6 +41,13 @@ pub fn init_ram(ram_reg:u8, external_ram:Option<&'static mut[u8]>)->&'static mut
         }
         None=>static_alloc_array(ram_size)
     }
+}
+
+/// Almost all MBC's external ram access are clipped to the ram size by masking with the relevent bits
+/// (Notice that all the avaliable sizes are left shifts of 1 and we assume `init_ram` initialized it).
+/// This emulates the bus to the chip with the amount of bits from the address the ram chip reads.
+pub(self) fn get_external_ram_valid_address(address:usize, external_ram:&[u8])->usize{
+    address as usize & (external_ram.len() - 1)
 }
 
 pub trait Mbc{

--- a/core/src/mmu/carts/rom.rs
+++ b/core/src/mmu/carts/rom.rs
@@ -29,11 +29,11 @@ impl<'a> Mbc for Rom<'a>{
     }
 
     fn read_external_ram(&self, address:u16)->u8{
-        self.external_ram[address as usize]
+        self.external_ram[get_external_ram_valid_address(address as usize, &self.external_ram)]
     }
 
     fn write_external_ram(&mut self, address:u16, value:u8){
-        self.external_ram[address as usize] = value
+        self.external_ram[get_external_ram_valid_address(address as usize, &self.external_ram)] = value
     }
 
     #[cfg(feature = "dbg")]

--- a/core/src/mmu/gb_mmu.rs
+++ b/core/src/mmu/gb_mmu.rs
@@ -58,7 +58,7 @@ impl<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider> Memory for GbMmu<'a, D, G
         if let Some(watch_value) = self.mem_watch.watching_addresses.get(&crate::debugger::Address::new(address, self.get_current_bank(address))){
             if watch_value.0 == crate::debugger::WatchMode::Read {
                 if watch_value.1.is_none() || watch_value.1.is_some_and(|v|v == value){
-                    self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+                    self.mem_watch.hit_addr = Some((crate::debugger::Address{ mem_addr: address, bank: self.get_current_bank(address) }, value));
                 }
             }
         }
@@ -71,7 +71,7 @@ impl<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider> Memory for GbMmu<'a, D, G
         if let Some(watch_value) = self.mem_watch.watching_addresses.get(&crate::debugger::Address::new(address, self.get_current_bank(address))){
             if watch_value.0 == crate::debugger::WatchMode::Write {
                 if watch_value.1.is_none() || watch_value.1.is_some_and(|v|v == value){
-                    self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+                    self.mem_watch.hit_addr = Some((crate::debugger::Address{ mem_addr: address, bank: self.get_current_bank(address) }, value));
                 }
             }
         }

--- a/core/src/mmu/gb_mmu.rs
+++ b/core/src/mmu/gb_mmu.rs
@@ -55,8 +55,12 @@ impl<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider> Memory for GbMmu<'a, D, G
         };
 
         #[cfg(feature = "dbg")]
-        if self.mem_watch.watching_addresses.contains(&(address, self.get_current_bank(address))){
-            self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+        if let Some(watch_value) = self.mem_watch.watching_addresses.get(&crate::debugger::Address::new(address, self.get_current_bank(address))){
+            if watch_value.0 == crate::debugger::WatchMode::Read {
+                if watch_value.1.is_none() || watch_value.1.is_some_and(|v|v == value){
+                    self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+                }
+            }
         }
 
         return value;
@@ -64,8 +68,12 @@ impl<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider> Memory for GbMmu<'a, D, G
 
     fn write(&mut self, address:u16, value:u8, m_cycles:u8){
         #[cfg(feature = "dbg")]
-        if self.mem_watch.watching_addresses.contains(&(address, self.get_current_bank(address))){
-            self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+        if let Some(watch_value) = self.mem_watch.watching_addresses.get(&crate::debugger::Address::new(address, self.get_current_bank(address))){
+            if watch_value.0 == crate::debugger::WatchMode::Write {
+                if watch_value.1.is_none() || watch_value.1.is_some_and(|v|v == value){
+                    self.mem_watch.hit_addr = Some((address, self.get_current_bank(address), value));
+                }
+            }
         }
 
         self.cycle(m_cycles);

--- a/core/src/mmu/gb_mmu.rs
+++ b/core/src/mmu/gb_mmu.rs
@@ -21,47 +21,51 @@ pub struct GbMmu<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider>{
 //DMA only locks the used bus. there 2 possible used buses: extrnal (wram, rom, sram) and video (vram)
 impl<'a, D:AudioDevice, G:GfxDevice, J:JoypadProvider> Memory for GbMmu<'a, D, G, J>{
     fn read(&mut self, address:u16, m_cycles:u8)->u8{
-        #[cfg(feature = "dbg")]
-        if self.mem_watch.watching_addresses.contains(&address){
-            self.mem_watch.hit_addr = Some(address);
-        }
-
         self.cycle(m_cycles);
-        if let Some (bus) = &self.occupied_access_bus{
-            return match address{
+        let value = if let Some (bus) = &self.occupied_access_bus{
+            match address{
                 0xFEA0..=0xFEFF | 0xFF00..=0xFFFF=>self.read_unprotected(address),
                 0x8000..=0x9FFF => if let AccessBus::External = bus {self.read_unprotected(address)} else{Self::bad_dma_read(address)},
                 0..=0x7FFF | 0xA000..=0xFDFF => if let AccessBus::Video = bus {self.read_unprotected(address)} else{Self::bad_dma_read(address)},
                 _=>Self::bad_dma_read(address)
-            };
-        }
-        return match address{
-            0x8000..=0x9FFF=>{
-                if self.is_vram_ready_for_io(){
-                    return self.io_bus.ppu.vram.read_current_bank(address-0x8000);
-                }
-                else{
-                    log::trace!("bad vram read");
-                    return BAD_READ_VALUE;
-                }
-            },
-            0xFE00..=0xFE9F=>{
-                if self.is_oam_ready_for_io(){
-                    return self.io_bus.ppu.oam[(address-0xFE00) as usize];
-                }
-                else{
-                    log::trace!("bad oam read");
-                    return BAD_READ_VALUE;
-                }
             }
-            _=>self.read_unprotected(address)
+        }
+        else{ 
+            match address{
+                0x8000..=0x9FFF=>{
+                    if self.is_vram_ready_for_io(){
+                        return self.io_bus.ppu.vram.read_current_bank(address-0x8000);
+                    }
+                    else{
+                        log::trace!("bad vram read");
+                        return BAD_READ_VALUE;
+                    }
+                },
+                0xFE00..=0xFE9F=>{
+                    if self.is_oam_ready_for_io(){
+                        return self.io_bus.ppu.oam[(address-0xFE00) as usize];
+                    }
+                    else{
+                        log::trace!("bad oam read");
+                        return BAD_READ_VALUE;
+                    }
+                }
+                _=>self.read_unprotected(address)
+            }
         };
+
+        #[cfg(feature = "dbg")]
+        if self.mem_watch.watching_addresses.contains(&address){
+            self.mem_watch.hit_addr = Some((address, value));
+        }
+
+        return value;
     }
 
     fn write(&mut self, address:u16, value:u8, m_cycles:u8){
         #[cfg(feature = "dbg")]
         if self.mem_watch.watching_addresses.contains(&address){
-            self.mem_watch.hit_addr = Some(address);
+            self.mem_watch.hit_addr = Some((address, value));
         }
 
         self.cycle(m_cycles);

--- a/core/src/ppu/gb_ppu.rs
+++ b/core/src/ppu/gb_ppu.rs
@@ -117,6 +117,7 @@ impl<GFX:GfxDevice> GbPpu<GFX>{
         unsafe{core::ptr::write_bytes(self.screen_buffers[self.current_screen_buffer_index].as_mut_ptr(), 0xFF, SCREEN_HEIGHT * SCREEN_WIDTH)};
         self.swap_buffer();
         self.state = PpuState::Hblank;
+        self.update_stat_ppu_mode();
         self.ly_register = 0;
         self.stat_triggered = false;
         self.trigger_stat_interrupt = false;
@@ -158,8 +159,7 @@ impl<GFX:GfxDevice> GbPpu<GFX>{
     }
 
     fn update_stat_register(&mut self, if_register: &mut u8) -> u32{
-        self.stat_register &= 0b1111_1100;
-        self.stat_register |= self.state as u8;
+        self.update_stat_ppu_mode();
         if self.ly_register == self.lyc_register{
             if self.coincidence_interrupt_request {
                 self.trigger_stat_interrupt = true;
@@ -191,6 +191,11 @@ impl<GFX:GfxDevice> GbPpu<GFX>{
         };
 
         return t_cycles_to_next_stat_change;
+    }
+
+    fn update_stat_ppu_mode(&mut self) {
+        self.stat_register &= 0b1111_1100;
+        self.stat_register |= self.state as u8;
     }
 
     fn cycle_fetcher(&mut self, m_cycles:u32, if_register:&mut u8)->u16{

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -113,6 +113,54 @@ fn test_cgb_acid2(){
     run_integration_test_from_url(file_url, 60, 1123147979104076695, Some(Mode::CGB));
 }
 
+#[test]
+fn test_magentests_ppu_off_stat_reg_state_cgb_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/ppu_disabled_state.gbc";
+    run_integration_test_from_url(file_url, 60, 6410113756445583331, Some(Mode::CGB));
+}
+
+#[test]
+fn test_magentests_ppu_off_stat_reg_state_dmg_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/ppu_disabled_state.gbc";
+    run_integration_test_from_url(file_url, 60, 3114957375595162924, Some(Mode::DMG));
+}
+
+#[test]
+fn test_magentests_mbc1_oob_access_cgb_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc1.gbc";
+    run_integration_test_from_url(file_url, 60, 6410113756445583331, Some(Mode::CGB));
+}
+
+#[test]
+fn test_magentests_mbc1_oob_access_dmg_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc1.gbc";
+    run_integration_test_from_url(file_url, 60, 3114957375595162924, Some(Mode::DMG));
+}
+
+#[test]
+fn test_magentests_mbc3_oob_access_cgb_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc3.gbc";
+    run_integration_test_from_url(file_url, 60, 6410113756445583331, Some(Mode::CGB));
+}
+
+#[test]
+fn test_magentests_mbc3_oob_access_dmg_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc3.gbc";
+    run_integration_test_from_url(file_url, 60, 3114957375595162924, Some(Mode::DMG));
+}
+
+#[test]
+fn test_magentests_mbc5_oob_access_cgb_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc5.gbc";
+    run_integration_test_from_url(file_url, 60, 6410113756445583331, Some(Mode::CGB));
+}
+
+#[test]
+fn test_magentests_mbc5_oob_access_dmg_mode(){
+    let file_url = "https://github.com/alloncm/MagenTests/releases/download/0.5.0/mbc_oob_sram_mbc5.gbc";
+    run_integration_test_from_url(file_url, 60, 3114957375595162924, Some(Mode::DMG));
+}
+
 fn run_turtle_integration_test(program_name:&str, hash:u64){
     let zip_url = "https://github.com/Powerlated/TurtleTests/releases/download/v1.0/release.zip";
     let program = get_ziped_program(zip_url, program_name);
@@ -183,9 +231,9 @@ fn run_integration_test(program:Vec<u8>, boot_rom:Option<Bootrom>, frames_to_exe
 #[test]
 #[ignore]
 fn generate_hash(){
-    let path = "path to rom";
+    let path = r"C:\Users\Alon\source\MagenTests\build\ppu_disabled_state.gbc";
     let boot_rom_path = None;
-    let mode = None;
+    let mode = Some(Mode::DMG);
     calc_hash(path, boot_rom_path, mode);
 }
 

--- a/docs/Debugger.md
+++ b/docs/Debugger.md
@@ -11,12 +11,13 @@ command | shortcut | description |  example
 halt    | h        | Halts the program execution in order to interact with the debugger | `halt`
 continue | c       | Continue the program execution (could be stopped again by entering the halt or by break points or watch points the user registered) | `continue`
 step | s           | Step the program 1 instruction    | `step`
-break [address] | b [address]         | Set a breakpoint at the given address, will break right before the instruction at this address is about to be executed | `break 0x1234`
-remove_break [address] | rb [address] | Remove a break point by the address | `remove_break 0x1234`
+skip_halt | - | skip untill CPU is hanlted
+break [address:bank] | b [address:bank]         | Set a breakpoint at the given address, will break right before the instruction at this address is about to be executed | `break 0x1234:1`
+remove_break [address:bank] | rb [address:bank] | Remove a break point by the address | `remove_break 0x1234:0`
 registers | reg | Display the registers values | `registers`
 disassemble [number_of_opcodes] | di [number_of_opcodes] | Display a disassembly of the current program counter | `disassemble 10`
-dump [number_of_bytes] | du [number_of_bytes] | Display a memory dump of the current program counter | `dump 10`
-watch [address] | w [address] | Set a watch point at the given address | `watch 0xFFFF`
-remove_watch [address] | rw [address] | Remove a watch point by the address | `remove_watch 0xFFFF`
+dump [address number_of_bytes] | du [address number_of_bytes] | Display a memory dump of the current bank at specific address | `dump 0x40 10`
+watch [address:bank] | w [address:bank] | Set a watch point at the given address | `watch 0xFFFF:0`
+remove_watch [address:bank] | rw [address:bank] | Remove a watch point by the address | `remove_watch 0xFFFF:0`
 ppu_info | pi | Display info about the current state of the pixel processing unit | `ppu_info`
 ppu_layer [layer] | pl [layer] | Render all the tiles in a given layer of the PPU memory, possible layers - [bg (background), win (window), spr (sprites/objects)] | `ppu_layer bg`

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -8,6 +8,7 @@ const HELP_MESSAGE:&'static str = r"Debugger commands:
 - halt(h) - start the debugging session (halt the program execution)
 - continue(c) - continue program execution
 - step(s) - step 1 instruction
+- skip_halt - skip untill CPU is hanlted
 - break(b) [address:bank] - set a break point
 - remove_break(rb) [address:bank] - delete a breakpoint 
 - registers(reg) - print the cpu registers state

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -107,8 +107,8 @@ impl TerminalDebugger{
                 }
             },
             DebuggerResult::AddedWatch(addr)=>println!("Set Watch point at: {addr} successfully"),
-            DebuggerResult::HitWatch(address, addr_bank, pc, pc_bank, value) => {
-                println!("Hit watch point: {address:#X}:{addr_bank} at address: {pc:#X}:{pc_bank} with value: {value:#X}");
+            DebuggerResult::HitWatch(address, pc_address, value) => {
+                println!("Hit watch point: {address:#X} at address: {pc:#X} with value: {value:#X}");
                 enabled.store(true, Ordering::SeqCst);
             },
             DebuggerResult::RemovedWatch(addr) => println!("Removed watch point {addr}"),

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -2,7 +2,7 @@ use std::{io::stdin, sync::{atomic::{AtomicBool, Ordering}, Arc}, thread};
 
 use crossbeam_channel::{bounded, Sender, Receiver};
 
-use magenboy_core::{debugger::{DebuggerCommand, DebuggerInterface, DebuggerResult, PpuLayer, PPU_BUFFER_SIZE}, Pixel};
+use magenboy_core::{debugger::{DebuggerCommand, DebuggerInterface, DebuggerResult, PpuLayer, PPU_BUFFER_SIZE, Address, WatchMode}, Pixel};
 
 const HELP_MESSAGE:&'static str = r"Debugger commands:
 - halt(h) - start the debugging session (halt the program execution)
@@ -11,13 +11,14 @@ const HELP_MESSAGE:&'static str = r"Debugger commands:
 - skip_halt - skip untill CPU is hanlted
 - break(b) [address:bank] - set a break point
 - remove_break(rb) [address:bank] - delete a breakpoint 
-- registers(reg) - print the cpu registers state
+- reg(r) - print the cpu registers state
 - disassemble(di) [number_of_opcodes] - print the disassembly of the next opcodes
 - dump(du) [address number_of_bytes] - print memory addresses values from current bank
-- watch(w) [address:bank] - set a watch point
+- watch(w) [address:bank R/W/RW optional_watch_value] - set a watch point
 - remove_watch(rw) [address:bank] - delete a watch point
 - ppu_info(pi) - print info about the ppu execution state
 - ppu_layer(pl) [layer] - a debug window with one ppu layer (win, bg, spr)
+- help - prints this help message
 ";
 
 pub struct PpuLayerResult(pub Box<[Pixel; PPU_BUFFER_SIZE]>, pub PpuLayer);
@@ -77,18 +78,18 @@ impl TerminalDebugger{
     fn handle_debugger_result(result:DebuggerResult, ppu_layer_sender:Sender<PpuLayerResult>, enabled:Arc<AtomicBool>){
         match result{
             DebuggerResult::Stopped(addr, bank) => println!("Stopped -> {:#X}:{}", addr, bank),
-            DebuggerResult::Registers(regs) => println!("AF: 0x{:X}\nBC: 0x{:X}\nDE: 0x{:X}\nHL: 0x{:X}\nSP: 0x{:X}\nPC: 0x{:X}",
-                                                            regs.af, regs.bc, regs.de, regs.hl, regs.sp, regs.pc),
+            DebuggerResult::Registers(regs) => println!("AF: 0x{:04X}\nBC: 0x{:04X}\nDE: 0x{:04X}\nHL: 0x{:04X}\nSP: 0x{:04X}\nPC: 0x{:04X}\nIME: {}",
+                                                            regs.af, regs.bc, regs.de, regs.hl, regs.sp, regs.pc, regs.ime),
             DebuggerResult::HitBreak(addr, bank) =>{
                 enabled.store(true, Ordering::SeqCst);
                 println!("Hit break: {:#X}:{}", addr, bank);
             }
             DebuggerResult::HaltWakeup => println!("Waked up from halt"),
-            DebuggerResult::AddedBreak(addr, bank)=>println!("Added BreakPoint successfully at address: {:#X}:{bank}", addr),
+            DebuggerResult::AddedBreak(addr)=>println!("Added BreakPoint successfully at address: {addr}"),
             DebuggerResult::Continuing=>println!("Continuing execution"),
             DebuggerResult::Stepped(addr, bank)=>println!("-> {:#X}:{}", addr, bank),
-            DebuggerResult::RemovedBreak(addr, bank) => println!("Removed breakpoint successfully at {:#X}:{}", addr, bank),
-            DebuggerResult::BreakDoNotExist(addr, bank) => println!("Breakpoint {:#X}:{} does not exist", addr, bank),
+            DebuggerResult::RemovedBreak(addr) => println!("Removed breakpoint successfully at {addr}"),
+            DebuggerResult::BreakDoNotExist(addr) => println!("Breakpoint {addr} does not exist"),
             DebuggerResult::MemoryDump(address, bank, buffer) => {
                 const SPACING: usize = 16;
                 for i in 0..buffer.len() as usize{
@@ -105,13 +106,13 @@ impl TerminalDebugger{
                     println!("{:#X}:{} {}", opcodes[i].address, bank, opcodes[i].string);
                 }
             },
-            DebuggerResult::AddedWatch(addr, bank)=>println!("Set Watch point at: {addr:#X}:{bank} successfully"),
+            DebuggerResult::AddedWatch(addr)=>println!("Set Watch point at: {addr} successfully"),
             DebuggerResult::HitWatch(address, addr_bank, pc, pc_bank, value) => {
                 println!("Hit watch point: {address:#X}:{addr_bank} at address: {pc:#X}:{pc_bank} with value: {value:#X}");
                 enabled.store(true, Ordering::SeqCst);
             },
-            DebuggerResult::RemovedWatch(addr, bank) => println!("Removed watch point {addr:#X}:{bank}"),
-            DebuggerResult::WatchDoNotExist(addr, bank) => println!("Watch point {addr:#X}:{bank} do not exist"),
+            DebuggerResult::RemovedWatch(addr) => println!("Removed watch point {addr}"),
+            DebuggerResult::WatchDoNotExist(addr) => println!("Watch point {addr} do not exist"),
             DebuggerResult::PpuInfo(info) => println!("PpuInfo: \nstate: {} \nlcdc: {:#X} \nstat: {:#X} \nly: {} \nbackground [X: {}, Y: {}] \nwindow [X: {}, Y: {}], \nbank: {}",
                 info.ppu_state as u8, info.lcdc, info.stat, info.ly, info.background_pos.x, info.background_pos.y, info.window_pos.x, info.window_pos.y, info.vram_bank),
             DebuggerResult::PpuLayer(layer, buffer) => ppu_layer_sender.send(PpuLayerResult(buffer, layer)).unwrap()
@@ -133,12 +134,12 @@ impl TerminalDebugger{
                     }
                     "s"|"step"=>sender.send(DebuggerCommand::Step).unwrap(),
                     "b"|"break"=>match parse_address_string(&buffer, 1) {
-                        Ok((address, bank)) => sender.send(DebuggerCommand::Break(address, bank)).unwrap(),
+                        Ok(address) => sender.send(DebuggerCommand::Break(address)).unwrap(),
                         Err(msg) => println!("Error setting BreakPoint {}", msg),
                     },
-                    "reg"|"registers"=>sender.send(DebuggerCommand::Registers).unwrap(),
+                    "r"|"reg"|"registers"=>sender.send(DebuggerCommand::Registers).unwrap(),
                     "rb"|"remove_break"=>match parse_address_string(&buffer, 1) {
-                        Ok((address, bank)) => sender.send(DebuggerCommand::RemoveBreak(address, bank)).unwrap(),
+                        Ok(address) => sender.send(DebuggerCommand::RemoveBreak(address)).unwrap(),
                         Err(msg) => println!("Error deleting BreakPoint {}", msg),
                     },
                     "di"|"disassemble"=>match parse_number_string(&buffer, 1){
@@ -150,12 +151,16 @@ impl TerminalDebugger{
                         (Err(msg), _) | 
                         (_, Err(msg)) => println!("Error dumping memory: {}", msg),
                     },
-                    "w"|"watch"=> match parse_address_string(&buffer, 1){
-                        Ok((addr, bank)) => sender.send(DebuggerCommand::Watch(addr, bank)).unwrap(),
-                        Err(msg) => println!("Error setting watch point {}", msg),
+                    "w"|"watch"=> match (parse_address_string(&buffer, 1), parse_watch_mode(&buffer, 2)){
+                        (Ok(addr), Ok(mode)) => {
+                            let watch_value:Option<u8> = parse_number_string(&buffer, 3).ok().map(|v|v.try_into().unwrap());
+                            sender.send(DebuggerCommand::Watch(addr, mode, watch_value)).unwrap()
+                        }
+                        (Err(msg), _) |
+                        (_, Err(msg)) => println!("Error setting watch point {}", msg),
                     }
                     "rw"|"remove_watch"=>match parse_address_string(&buffer, 1){
-                        Ok((addr, bank)) => sender.send(DebuggerCommand::RemoveWatch(addr, bank)).unwrap(),
+                        Ok(addr) => sender.send(DebuggerCommand::RemoveWatch(addr)).unwrap(),
                         Err(msg) => println!("Error deleting watch point: {}", msg),
                     },
                     "pi"|"ppu_info"=>sender.send(DebuggerCommand::PpuInfo).unwrap(),
@@ -174,14 +179,14 @@ impl TerminalDebugger{
 }
 
 /// Address is "memory_address:bank" format
-fn parse_address_string(buffer: &Vec<&str>, index:usize)->Result<(u16, u16), String>{
+fn parse_address_string(buffer: &Vec<&str>, index:usize)->Result<Address, String>{
     let Some(param) = buffer.get(index) else {
         return Result::Err(String::from("No parameter"))
     };
     let strs:Vec<&str> = param.split(":").collect();
     let mem_addr = parse_number_string(&strs, 0)?;
     let bank = parse_number_string(&strs, 1)?;
-    return Ok((mem_addr, bank));
+    return Ok(Address::new(mem_addr, bank));
 }   
 
 fn parse_number_string(buffer: &Vec<&str>, index:usize) -> Result<u16, String> {
@@ -206,6 +211,20 @@ fn parse_ppu_layer(buffer: &Vec<&str>)->Result<PpuLayer, String>{
         "spr" => Ok(PpuLayer::Sprites),
         "bg" => Ok(PpuLayer::Background),
         _=> Err(String::from("No matching layer"))
+    };
+}
+
+fn parse_watch_mode(buffer: &Vec<&str>, index:usize)->Result<WatchMode, String>{
+    let Some(param) = buffer.get(index) else {
+        return Result::Err(String::from("No parameter"))
+    };
+    
+    return match param.to_ascii_lowercase().as_str(){
+        "r" => Ok(WatchMode::Read),
+        "w" => Ok(WatchMode::Write),
+        "rw" |
+        "wr" => Ok(WatchMode::ReadWrite),
+        _=>Err(String::from("Could not find watch mode (r/w/rw"))
     };
 }
 

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -11,8 +11,8 @@ const HELP_MESSAGE:&'static str = r"Debugger commands:
 - break(b) [address:bank] - set a break point
 - remove_break(rb) [address:bank] - delete a breakpoint 
 - registers(reg) - print the cpu registers state
-- disassemble(di) [number of opcodes] - print the disassembly of the next opcodes
-- dump(du) [number of bytes] - print next the memory addresses values
+- disassemble(di) [number_of_opcodes] - print the disassembly of the next opcodes
+- dump(du) [address number_of_bytes] - print memory addresses values
 - watch(w) [address:bank] - set a watch point
 - remove_watch(rw) [address:bank] - delete a watch point
 - ppu_info(pi) - print info about the ppu execution state

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -77,25 +77,25 @@ impl TerminalDebugger{
     
     fn handle_debugger_result(result:DebuggerResult, ppu_layer_sender:Sender<PpuLayerResult>, enabled:Arc<AtomicBool>){
         match result{
-            DebuggerResult::Stopped(addr, bank) => println!("Stopped -> {:#X}:{}", addr, bank),
+            DebuggerResult::Stopped(addr) => println!("Stopped -> {}", addr),
             DebuggerResult::Registers(regs) => println!("AF: 0x{:04X}\nBC: 0x{:04X}\nDE: 0x{:04X}\nHL: 0x{:04X}\nSP: 0x{:04X}\nPC: 0x{:04X}\nIME: {}",
                                                             regs.af, regs.bc, regs.de, regs.hl, regs.sp, regs.pc, regs.ime),
-            DebuggerResult::HitBreak(addr, bank) =>{
+            DebuggerResult::HitBreak(addr) =>{
                 enabled.store(true, Ordering::SeqCst);
-                println!("Hit break: {:#X}:{}", addr, bank);
+                println!("Hit break: {}", addr);
             }
             DebuggerResult::HaltWakeup => println!("Waked up from halt"),
             DebuggerResult::AddedBreak(addr)=>println!("Added BreakPoint successfully at address: {addr}"),
             DebuggerResult::Continuing=>println!("Continuing execution"),
-            DebuggerResult::Stepped(addr, bank)=>println!("-> {:#X}:{}", addr, bank),
+            DebuggerResult::Stepped(addr)=>println!("-> {}", addr),
             DebuggerResult::RemovedBreak(addr) => println!("Removed breakpoint successfully at {addr}"),
             DebuggerResult::BreakDoNotExist(addr) => println!("Breakpoint {addr} does not exist"),
-            DebuggerResult::MemoryDump(address, bank, buffer) => {
+            DebuggerResult::MemoryDump(address, buffer) => {
                 const SPACING: usize = 16;
                 for i in 0..buffer.len() as usize{
                     if i % SPACING == 0 { 
                         println!();
-                        print!("{:#X}:{}: ", address + i as u16 , bank);
+                        print!("{:#X}:{}: ", address.mem_addr + i as u16 , address.bank);
                     }
                     print!("{:#04X}, ", buffer[i]);
                 }
@@ -108,7 +108,7 @@ impl TerminalDebugger{
             },
             DebuggerResult::AddedWatch(addr)=>println!("Set Watch point at: {addr} successfully"),
             DebuggerResult::HitWatch(address, pc_address, value) => {
-                println!("Hit watch point: {address:#X} at address: {pc:#X} with value: {value:#X}");
+                println!("Hit watch point: {address} at address: {pc_address} with value: {value:#X}");
                 enabled.store(true, Ordering::SeqCst);
             },
             DebuggerResult::RemovedWatch(addr) => println!("Removed watch point {addr}"),

--- a/sdl/src/terminal_debugger.rs
+++ b/sdl/src/terminal_debugger.rs
@@ -12,7 +12,7 @@ const HELP_MESSAGE:&'static str = r"Debugger commands:
 - remove_break(rb) [address:bank] - delete a breakpoint 
 - registers(reg) - print the cpu registers state
 - disassemble(di) [number_of_opcodes] - print the disassembly of the next opcodes
-- dump(du) [address number_of_bytes] - print memory addresses values
+- dump(du) [address number_of_bytes] - print memory addresses values from current bank
 - watch(w) [address:bank] - set a watch point
 - remove_watch(rw) [address:bank] - delete a watch point
 - ppu_info(pi) - print info about the ppu execution state
@@ -95,7 +95,7 @@ impl TerminalDebugger{
                         println!();
                         print!("{:#X}:{}: ", address + i as u16 , bank);
                     }
-                    print!("{:#04x}, ", buffer[i]);
+                    print!("{:#04X}, ", buffer[i]);
                 }
                 println!();
             },


### PR DESCRIPTION
- Pokemon Pinball no longer crash on boot
  - Fix the stat register not updating the PPU mode when disabled
  - Add support for 0x1E cart mode (MBC5)
  - Fix MBC5 to ignore out of bounds cart ram (sram) writes and reads
- Improve the debugger 
  - Update docs and help command
  - Add bank specifier to the watch commands
  - Add watch values and r/w modes to the watch command
  - Improve some commands text output